### PR TITLE
Added version-tag to manifest

### DIFF
--- a/custom_components/birthdays/manifest.json
+++ b/custom_components/birthdays/manifest.json
@@ -4,5 +4,6 @@
     "documentation": "https://github.com/Miicroo/ha-birthdays",
     "dependencies": [],
     "codeowners": ["@Miicroo"],
-    "requirements": []
+    "requirements": [],
+    "version": "1.0.1"
 }


### PR DESCRIPTION
Needed to work in 2021.5

https://www.home-assistant.io/blog/2021/05/05/release-20215/