### PR TITLE
fix: Update asyncio wait to be compatible with HA 2023.6

### DIFF
--- a/custom_components/birthdays/__init__.py
+++ b/custom_components/birthdays/__init__.py
@@ -42,7 +42,7 @@ async def async_setup(hass, config):
     await component.async_add_entities(devices)
 
 
-    tasks = [device.update_data() for device in devices]
+    tasks = [asyncio.create_task(device.update_data()) for device in devices]
     await asyncio.wait(tasks)
 
     return True


### PR DESCRIPTION
This is a possible fix for https://github.com/Miicroo/ha-birthdays/issues/10

I followed the example of https://github.com/AngellusMortis/pyunifiprotect/pull/284/files to PR this but I have not tested it locally yet.